### PR TITLE
fix publicpath for external urls

### DIFF
--- a/config/head-config.common.js
+++ b/config/head-config.common.js
@@ -27,8 +27,8 @@ module.exports = {
     { rel: 'apple-touch-icon', sizes: '180x180', href: '/assets/icon/apple-icon-180x180.png' },
 
     /** <link> tags to the material design assets */
-    { rel: 'stylesheet', href : 'https://unpkg.com/@angular/material/core/theming/prebuilt/indigo-pink.css' },
-    { rel: 'stylesheet', href: 'https://fonts.googleapis.com/icon?family=Material+Icons'},
+    { rel: 'stylesheet', href : 'https://unpkg.com/@angular/material/core/theming/prebuilt/indigo-pink.css', '=href': false},
+    { rel: 'stylesheet', href: 'https://fonts.googleapis.com/icon?family=Material+Icons', '=href': false},
 
     /** <link> tags for android web app icons **/
     { rel: 'icon', type: 'image/png', sizes: '192x192', href: '/assets/icon/android-icon-192x192.png' },


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

bug fix

* **What is the current behavior?** (You can also link to an open issue here)

publichPath applied for external urls

* **What is the new behavior (if this is a feature change)?**

set , '=href': false for material css/icon urls

* **Other information**:

publicpath was applied to external urls, which should not happen